### PR TITLE
State scoped variables more precisely

### DIFF
--- a/HowToWriteGoodTestCases.rst
+++ b/HowToWriteGoodTestCases.rst
@@ -477,8 +477,10 @@ Variable naming
 
 - Use case consistently:
 
-  - Lower case with local variables only available inside a certain scope.
-  - Upper case with others (global, suite or test level).
+  - All variables are globally defined. To indicate a scoped variable, use
+    lower case.
+  - Upper case with variables that are shared between test cases or keywords
+    (global, suite or test level).
   - Both space and underscore can be used as a word separator.
 
 - Recommended to also list variables that are set dynamically in the variable


### PR DESCRIPTION
Before it was kind of unclear, if you should use lower or upper case in
test cases.
I interpreted this: Yes, they should be lower case, unless
they are used (but not passed!) in keywords.
This is now more clear (to me).