### PR TITLE
Update HowToWriteGoodTestCases.rst

### DIFF
--- a/HowToWriteGoodTestCases.rst
+++ b/HowToWriteGoodTestCases.rst
@@ -495,7 +495,7 @@ Example:
   Suite Setup       Set Active User
 
   *** Variables ***
-  # Default system address. Override when tested agains other instances.
+  # Default system address. Override when tested against other instances.
   ${SERVER URL}     http://sre-12.example.com/
   ${USER}           Actual value set dynamically at suite setup
 


### PR DESCRIPTION
[Correct] Misspelling in line 498 for the word "against".